### PR TITLE
Added reference to homie-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can find an implementation of the Homie convention:
 * An Arduino library built for the ESP8266: [marvinroger/homie-esp8266](https://github.com/marvinroger/homie-esp8266)
 * ![WIP](https://cdn2.iconfinder.com/data/icons/thesquid-ink-40-free-flat-icon-pack/64/barricade-24.png) **WIP** - An opinionated Web UI built with Node.js: [marvinroger/homie-server](https://github.com/marvinroger/homie-server)
 * ![WIP](https://cdn2.iconfinder.com/data/icons/thesquid-ink-40-free-flat-icon-pack/64/barricade-24.png) **WIP** - Some Node-RED nodes for automation: [marvinroger/node-red-contrib-homie](https://github.com/marvinroger/node-red-contrib-homie)
+* A Python-implementation for Raspberry Pi & Co.: [jalmeroth/homie-python](https://github.com/jalmeroth/homie-python).
 
 ## Background
 


### PR DESCRIPTION
homie-python will be compatible with homie v2, when homie-esp8266 v2
will be released. For development progress take a look at:
https://github.com/jalmeroth/homie-python/tree/dev