### PR TITLE
$unit should not be mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ homie/686f6d6965/$fw/version → 1.0.0
             <code>#</code> Count or Amount
         </td>
         <td>Yes</td>
-        <td>Yes</td>
+        <td>Yes, if applicable.<br /> If $unit is omitted, it is assumed that the property is unit-less, e.g. a discrete state.</td>
     </tr>
     <tr>
        <td>$datatype</td>


### PR DESCRIPTION
For example, ENUMs and Strings are usually unit-less.