### PR TITLE
:fire: $unit should not be mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ A property attribute MUST be one of these:
             <code>#</code> Count or Amount
         </td>
         <td>Yes</td>
-        <td>Yes</td>
+        <td>Yes, if applicable.<br /> If $unit is omitted, it is assumed that the property is unit-less, e.g. a discrete state.</td>
     </tr>
     <tr>
        <td>$datatype</td>


### PR DESCRIPTION
For example, ENUMs and Strings are usually unit-less.

